### PR TITLE
enable full percentile spectrum analysis on latency. enable maintaining fixed rps during query benchmarks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 .DS_Store
 .idea
 .vscode
+
+# High Dynamic Range (HDR) Histogram files
+*.hdr

--- a/query/stats_test.go
+++ b/query/stats_test.go
@@ -78,35 +78,38 @@ func TestStateGroupMedian(t *testing.T) {
 			want: 1.0,
 		},
 		{
-			len:  2,
-			want: 2.0,
-		},
-		{
-			len:  4,
-			want: 4.0,
-		},
-		{
 			len:  5,
 			want: 5.0,
 		},
 		{
-			len:  1000,
-			want: 1000,
+			len:  99,
+			want: 99.0,
+		},
+		{
+			len:  999,
+			want: 999.0,
+		},
+		{
+			len:  9999,
+			want: 9999.0,
 		},
 	}
-
+	errorMargin := 0.0001
 	for _, c := range cases {
 		sg := newStatGroup(c.len)
 		for i := uint64(0); i < c.len; i++ {
 			sg.push(1 + float64(i)*2)
 		}
-		if got := sg.median(); c.want != got {
-			t.Errorf("got: %v want: %v\n", got, c.want)
+		lowerLimit := c.want - (c.want*errorMargin)
+		upperLimit := c.want + (c.want*errorMargin)
+		if got := sg.median(); ( (lowerLimit > got) && ( got > upperLimit )  && got != 0 ) || got == 0 && got!=c.want {
+			t.Errorf("got: %v want C [ %v,%v ]\n", got, lowerLimit, upperLimit)
 		}
 	}
 }
 
 func TestStatGroupMedian0InitialSize(t *testing.T) {
+	errorMargin := 0.0001
 	cases := []struct {
 		len  uint64
 		want float64
@@ -120,20 +123,20 @@ func TestStatGroupMedian0InitialSize(t *testing.T) {
 			want: 1.0,
 		},
 		{
-			len:  2,
-			want: 2.0,
-		},
-		{
-			len:  4,
-			want: 4.0,
-		},
-		{
 			len:  5,
 			want: 5.0,
 		},
 		{
-			len:  1000,
-			want: 1000,
+			len:  99,
+			want: 99.0,
+		},
+		{
+			len:  999,
+			want: 999.0,
+		},
+		{
+			len:  9999,
+			want: 9999.0,
 		},
 	}
 
@@ -142,8 +145,10 @@ func TestStatGroupMedian0InitialSize(t *testing.T) {
 		for i := uint64(0); i < c.len; i++ {
 			sg.push(1 + float64(i)*2)
 		}
-		if got := sg.median(); c.want != got {
-			t.Errorf("got: %v want: %v\n", got, c.want)
+		lowerLimit := c.want - (c.want*errorMargin)
+		upperLimit := c.want + (c.want*errorMargin)
+		if got := sg.median(); ( (lowerLimit > got) && ( got > upperLimit )  && got != 0 ) || got == 0 && got!=c.want {
+			t.Errorf("got: %v want C [ %v,%v ]\n", got, lowerLimit, upperLimit)
 		}
 	}
 }
@@ -192,13 +197,13 @@ func TestStatGroupPush(t *testing.T) {
 		for _, val := range c.vals {
 			sg.push(val)
 		}
-		if got := sg.min; got != c.wantMin {
+		if got := sg.Min(); got != c.wantMin {
 			t.Errorf("%s: incorrect min: got %f want %f", c.desc, got, c.wantMin)
 		}
-		if got := sg.max; got != c.wantMax {
+		if got := sg.Max(); got != c.wantMax {
 			t.Errorf("%s: incorrect max: got %f want %f", c.desc, got, c.wantMin)
 		}
-		if got := sg.mean; got != c.wantMean {
+		if got := sg.Mean(); got != c.wantMean {
 			t.Errorf("%s: incorrect mean: got %f want %f", c.desc, got, c.wantMin)
 		}
 		if got := sg.count; got != c.wantCount {

--- a/scripts/full_cycle_minitest_clickhouse.sh
+++ b/scripts/full_cycle_minitest_clickhouse.sh
@@ -1,15 +1,19 @@
 #!/bin/bash
 
+MAX_RPS=${MAX_RPS:-"0"}
+MAX_QUERIES=${MAX_QUERIES:-"1000"}
+PASSWORD=${PASSWORD:-""}
+
 $GOPATH/bin/tsbs_generate_data --format clickhouse --use-case cpu-only --scale 10 --seed 123 --file /tmp/bulk_data/clickhouse_data
 
-$GOPATH/bin/tsbs_generate_queries --format clickhouse --use-case cpu-only --scale 10 --seed 123 --query-type lastpoint     --file /tmp/bulk_data/clickhouse_query_lastpoint
-$GOPATH/bin/tsbs_generate_queries --format clickhouse --use-case cpu-only --scale 10 --seed 123 --query-type cpu-max-all-1 --file /tmp/bulk_data/clickhouse_query_cpu-max-all-1
-$GOPATH/bin/tsbs_generate_queries --format clickhouse --use-case cpu-only --scale 10 --seed 123 --query-type high-cpu-1    --file /tmp/bulk_data/clickhouse_query_high-cpu-1
+$GOPATH/bin/tsbs_generate_queries --queries=${MAX_QUERIES} --format clickhouse --use-case cpu-only --scale 10 --seed 123 --query-type lastpoint     --file /tmp/bulk_data/clickhouse_query_lastpoint
+$GOPATH/bin/tsbs_generate_queries --queries=${MAX_QUERIES} --format clickhouse --use-case cpu-only --scale 10 --seed 123 --query-type cpu-max-all-1 --file /tmp/bulk_data/clickhouse_query_cpu-max-all-1
+$GOPATH/bin/tsbs_generate_queries --queries=${MAX_QUERIES} --format clickhouse --use-case cpu-only --scale 10 --seed 123 --query-type high-cpu-1    --file /tmp/bulk_data/clickhouse_query_high-cpu-1
 
 $GOPATH/bin/tsbs_load_clickhouse --db-name=benchmark --host=127.0.0.1 --workers=1 --file=/tmp/bulk_data/clickhouse_data
-
-$GOPATH/bin/tsbs_run_queries_clickhouse --db-name=benchmark --hosts=127.0.0.1 --workers=1 --max-queries=100 --file=/tmp/bulk_data/clickhouse_query_lastpoint
-$GOPATH/bin/tsbs_run_queries_clickhouse --db-name=benchmark --hosts=127.0.0.1 --workers=1 --max-queries=100 --file=/tmp/bulk_data/clickhouse_query_cpu-max-all-1
-$GOPATH/bin/tsbs_run_queries_clickhouse --db-name=benchmark --hosts=127.0.0.1 --workers=1 --max-queries=100 --file=/tmp/bulk_data/clickhouse_query_high-cpu-1
+#last point query is broke
+#$GOPATH/bin/tsbs_run_queries_clickhouse --max-rps=${MAX_RPS} --hdr-latencies="${MAX_RPS}rps_clickhouse_query_lastpoint.hdr" --db-name=benchmark --hosts=127.0.0.1 --workers=1 --max-queries=${MAX_QUERIES} --file=/tmp/bulk_data/clickhouse_query_lastpoint
+$GOPATH/bin/tsbs_run_queries_clickhouse --max-rps=${MAX_RPS} --hdr-latencies="${MAX_RPS}rps_clickhouse_query_cpu-max-all-1.hdr" --db-name=benchmark --hosts=127.0.0.1 --workers=1 --max-queries=${MAX_QUERIES} --file=/tmp/bulk_data/clickhouse_query_cpu-max-all-1
+$GOPATH/bin/tsbs_run_queries_clickhouse --max-rps=${MAX_RPS} --hdr-latencies="${MAX_RPS}rps_clickhouse_query_high-cpu-1.hdr" --db-name=benchmark --hosts=127.0.0.1 --workers=1 --max-queries=${MAX_QUERIES} --file=/tmp/bulk_data/clickhouse_query_high-cpu-1
 
 

--- a/scripts/full_cycle_minitest_timescaledb.sh
+++ b/scripts/full_cycle_minitest_timescaledb.sh
@@ -1,13 +1,17 @@
 #!/bin/bash
 
+MAX_RPS=${MAX_RPS:-"0"}
+MAX_QUERIES=${MAX_QUERIES:-"1000"}
+PASSWORD=${PASSWORD:-""}
+
 $GOPATH/bin/tsbs_generate_data --format timescaledb --use-case cpu-only --scale 10 --seed 123 --file /tmp/bulk_data/timescaledb_data
 
-$GOPATH/bin/tsbs_generate_queries --format timescaledb --use-case cpu-only --scale 10 --seed 123 --query-type lastpoint     --file /tmp/bulk_data/timescaledb_query_lastpoint
-$GOPATH/bin/tsbs_generate_queries --format timescaledb --use-case cpu-only --scale 10 --seed 123 --query-type cpu-max-all-1 --file /tmp/bulk_data/timescaledb_query_cpu-max-all-1
-$GOPATH/bin/tsbs_generate_queries --format timescaledb --use-case cpu-only --scale 10 --seed 123 --query-type high-cpu-1    --file /tmp/bulk_data/timescaledb_query_high-cpu-1
+$GOPATH/bin/tsbs_generate_queries --queries=${MAX_QUERIES} --format timescaledb --use-case cpu-only --scale 10 --seed 123 --query-type lastpoint     --file /tmp/bulk_data/timescaledb_query_lastpoint
+$GOPATH/bin/tsbs_generate_queries --queries=${MAX_QUERIES} --format timescaledb --use-case cpu-only --scale 10 --seed 123 --query-type cpu-max-all-1 --file /tmp/bulk_data/timescaledb_query_cpu-max-all-1
+$GOPATH/bin/tsbs_generate_queries --queries=${MAX_QUERIES} --format timescaledb --use-case cpu-only --scale 10 --seed 123 --query-type high-cpu-1    --file /tmp/bulk_data/timescaledb_query_high-cpu-1
 
-$GOPATH/bin/tsbs_load_timescaledb --postgres="sslmode=disable port=5433" --db-name=benchmark --host=127.0.0.1 --user=postgres --workers=1 --file=/tmp/bulk_data/timescaledb_data
+$GOPATH/bin/tsbs_load_timescaledb --pass=${PASSWORD} --postgres="sslmode=disable port=5433" --db-name=benchmark --host=127.0.0.1 --user=postgres --workers=1 --file=/tmp/bulk_data/timescaledb_data
 
-$GOPATH/bin/tsbs_run_queries_timescaledb --postgres="sslmode=disable port=5433" --db-name=benchmark --hosts=127.0.0.1 --user=postgres --workers=1 --max-queries=100 --file=/tmp/bulk_data/timescaledb_query_lastpoint
-$GOPATH/bin/tsbs_run_queries_timescaledb --postgres="sslmode=disable port=5433" --db-name=benchmark --hosts=127.0.0.1 --user=postgres --workers=1 --max-queries=100 --file=/tmp/bulk_data/timescaledb_query_cpu-max-all-1
-$GOPATH/bin/tsbs_run_queries_timescaledb --postgres="sslmode=disable port=5433" --db-name=benchmark --hosts=127.0.0.1 --user=postgres --workers=1 --max-queries=100 --file=/tmp/bulk_data/timescaledb_query_high-cpu-1
+$GOPATH/bin/tsbs_run_queries_timescaledb --max-rps=${MAX_RPS} --hdr-latencies="${MAX_RPS}rps_timescaledb_query_lastpoint.hdr" --pass=${PASSWORD} --postgres="sslmode=disable port=5433" --db-name=benchmark --hosts=127.0.0.1 --user=postgres --workers=1 --max-queries=${MAX_QUERIES} --file=/tmp/bulk_data/timescaledb_query_lastpoint
+$GOPATH/bin/tsbs_run_queries_timescaledb --max-rps=${MAX_RPS} --hdr-latencies="${MAX_RPS}rps_timescaledb_query_cpu-max-all-1.hdr" --pass=${PASSWORD} --postgres="sslmode=disable port=5433" --db-name=benchmark --hosts=127.0.0.1 --user=postgres --workers=1 --max-queries=${MAX_QUERIES} --file=/tmp/bulk_data/timescaledb_query_cpu-max-all-1
+$GOPATH/bin/tsbs_run_queries_timescaledb --max-rps=${MAX_RPS} --hdr-latencies="${MAX_RPS}rps_timescaledb_query_high-cpu-1.hdr" --pass=${PASSWORD} --postgres="sslmode=disable port=5433" --db-name=benchmark --hosts=127.0.0.1 --user=postgres --workers=1 --max-queries=${MAX_QUERIES} --file=/tmp/bulk_data/timescaledb_query_high-cpu-1


### PR DESCRIPTION



# Full percentile spectrum analysis
This PR enable full percentile spectrum analysis on query latency so that we can fully understand the performance and stability characteristics of the system we are measuring. 

Right now tsbs is displaying single values targets like the quantile 50, average, min and max. 
Considering that latency does not obey to a normal distribution we should enable ourselfs to do full percentile spectrum analysis. Just looking at a number might be misleading. 

A useful visualization for pointing out the folly of chasing a mean measurement is illustrated below - they have nearly identical simple descriptive statistics, yet have very different distributions and appear very different when graphed.

![image](https://user-images.githubusercontent.com/5832149/67484927-f4734880-f660-11e9-9400-6e0dc09a8a87.png)


Source: https://en.wikipedia.org/wiki/Anscombe%27s_quartet

_______
# Sustainable Throughput:
With that in mind, and to really understand a system behavior we also cant relly solely on doing the full percentile analysis while stressing the system to it's maximum RPS. We need to be able to compare the behavior under different throughputs and/or configurations, to be able to get the best "Sustainable Throughput: The throughput achieved while safely maintaining service levels. 

Adding a further reading slide that will help you understand why this is so important:

https://www.azul.com/files/HowNotToMeasureLatency_LLSummit_NYC_12Nov2013.pdf

![image](https://user-images.githubusercontent.com/5832149/67485495-0ef9f180-f662-11e9-9814-ccfe67f4edc0.png)

_______
# Enabling full percentile spectrum and Sustainable Throughput analysis on tsbs:

The previous features can be applied with the changes added on this PR using the following flags on the `tsbs_run_queries_*` binaries:
-` --hdr-latencies` : enable writing the High Dynamic Range (HDR) Histogram of Response Latencies to the file with the name specified by this. By default no file will be saved. 
-` --max-rps` : enable limiting the rate of queries per second, 0 = no limit. By default no limit is specified and the binaries will behave in the same manner as before. 

## quick example of the beneficts of this addition
Take into consideration that the presented values were obtained to illustrate the added features and not to compared the used systems. This was a local test that should not be used for any other thing rather than to exemplify the new way of assessing stability and performance across the entire latency spectrum when using HDR histograms and rate-limiting.  

### Step 1 - Setup
Running two example docker containers from clickhouse and  timescale in the following manner:
```
docker run -d -p 9000:9000 --ulimit nofile=262144:262144 yandex/clickhouse-server
docker run -d -e POSTGRES_PASSWORD=password -p 5432:5432 timescale/timescaledb
```
### Step 2 - Retrieve sample values
Running two example docker containers from clickhouse and  timescale in the following manner:
```
MAX_QUERIES=1000 MAX_RPS=100 ./scripts/full_cycle_minitest_clickhouse.sh
MAX_QUERIES=1000 MAX_RPS=100 PASSWORD="password" ./scripts/full_cycle_minitest_timescaledb.sh
```
Sample output ( please denote the added `Interval query rate` and `Overall query rate` values
```
(...)
After 100 queries with 1 workers:
Interval query rate: 99.74 queries/sec  Overall query rate: 99.74 queries/sec
ClickHouse CPU over threshold, 1 host(s):
min:     6.03ms, med:     7.36ms, mean:     7.59ms, max:   11.82ms, stddev:     1.12ms, sum:   0.8sec, count: 100
all queries                             :
min:     6.03ms, med:     7.36ms, mean:     7.59ms, max:   11.82ms, stddev:     1.12ms, sum:   0.8sec, count: 100
(...)
```
Final Query benchmark output ( please denote the info regarding in which file the HDR latency file was saved 
```
(...)
Run complete after 1000 queries with 1 workers (Overall query rate 98.42 queries/sec):
ClickHouse CPU over threshold, 1 host(s):
min:     5.78ms, med:     7.52ms, mean:     7.90ms, max:  111.44ms, stddev:     3.54ms, sum:   7.9sec, count: 1000
all queries                             :
min:     5.78ms, med:     7.52ms, mean:     7.90ms, max:  111.44ms, stddev:     3.54ms, sum:   7.9sec, count: 1000
Saving High Dynamic Range (HDR) Histogram of Response Latencies to 100rps_clickhouse_query_high-cpu-1.hdr
wall clock time: 10.178806sec
```
### Step 3 - Use HdrHistogram Plotter
Using the two first output files from the simple full cycle mini tests we can plot the Latency by Percentile Distribution using http://hdrhistogram.github.io/HdrHistogram/plotFiles.html

- [100rps_clickhouse_query_high-cpu-1.txt](https://github.com/filipecosta90/tsbs/files/3767556/100rps_clickhouse_query_high-cpu-1.txt)
- [100rps_timescaledb_query_high-cpu-1.txt](https://github.com/filipecosta90/tsbs/files/3767558/100rps_timescaledb_query_high-cpu-1.txt)
- [100rps_clickhouse_query_cpu-max-all-1.txt](https://github.com/filipecosta90/tsbs/files/3767555/100rps_clickhouse_query_cpu-max-all-1.txt)
- [100rps_timescaledb_query_cpu-max-all-1.txt](https://github.com/filipecosta90/tsbs/files/3767557/100rps_timescaledb_query_cpu-max-all-1.txt)

Which will enable us to get the "full picture" of latency distribution. If we only analyzed the P99 latency we would be tempted to state that clickhouse had better values. However, if you look and the second image you see that on overall  the stability of timescale is greater. Take into consideration that obtained values are only for illustration purposes and to justify that single values targets can lead us to the wrong conclusions. 

![Screen Shot 2019-10-24 at 1 46 58 PM](https://user-images.githubusercontent.com/5832149/67487067-29819a00-f665-11e9-8300-1a0db871bd23.png)
![Screen Shot 2019-10-24 at 1 46 44 PM](https://user-images.githubusercontent.com/5832149/67487098-3c946a00-f665-11e9-9b7c-470e6b8c4e07.png)


# credits 
HdrHistogram was originally authored by Gil Tene (@giltene) and placed in the public domain, as explained at http://creativecommons.org/publicdomain/zero/1.0/, with ports by Mike Barker (@mikeb01) (C), Matt Warren (@mattwarren) (C#), Darach Ennis (@darach) (Erlang), Alec Hothan (@ahothan) (Python), Coda Hale (@codahale) (Go) (which i needed to revamp), Jon Gjengset (@jonhoo) (Rust), and Alexandre Victoor (@alexvictoor) (JavaScript)

